### PR TITLE
Enhance order details with product images and size clarity

### DIFF
--- a/Art_Touch/Controllers/AdminController.cs
+++ b/Art_Touch/Controllers/AdminController.cs
@@ -39,6 +39,7 @@ namespace Art_Touch.Controllers
             var products = await _context.Products
                 .Include(p => p.Category)
                 .Include(p => p.Sizes)
+                .Include(p => p.Images)
                 .ToListAsync();
             return View(products);
         }
@@ -371,6 +372,7 @@ namespace Art_Touch.Controllers
                 .Include(o => o.User)
                 .Include(o => o.Items)
                 .ThenInclude(oi => oi.Product)
+                .ThenInclude(p => p.Images)
                 .FirstOrDefaultAsync(o => o.Id == id);
                 
             if (order == null) return NotFound();

--- a/Art_Touch/Views/Admin/Products.cshtml
+++ b/Art_Touch/Views/Admin/Products.cshtml
@@ -30,6 +30,7 @@
                     <thead>
                         <tr>
                             <th>ID</th>
+                            <th style="width: 80px;">Image</th>
                             <th>Name</th>
                             <th>Category</th>
                             <th>Price</th>
@@ -44,6 +45,26 @@
                         {
                             <tr>
                                 <td>@product.Id</td>
+                                <td>
+                                    @{
+                                        var coverImage = product.Images?.FirstOrDefault(i => i.IsCover);
+                                    }
+                                    @if (coverImage != null)
+                                    {
+                                        <img src="@coverImage.ImageUrl" 
+                                             class="img-fluid rounded" 
+                                             style="width: 60px; height: 60px; object-fit: cover;" 
+                                             onerror="this.src='/images/placeholder-dress.jpg'; this.onerror=null;"
+                                             alt="@product.Name" />
+                                    }
+                                    else
+                                    {
+                                        <div class="d-flex align-items-center justify-content-center bg-light rounded" 
+                                             style="width: 60px; height: 60px;">
+                                            <i class="fas fa-image text-muted"></i>
+                                        </div>
+                                    }
+                                </td>
                                 <td>
                                     <div>
                                         <strong>@product.Name</strong>

--- a/Art_Touch/Views/Admin/_OrderDetails.cshtml
+++ b/Art_Touch/Views/Admin/_OrderDetails.cshtml
@@ -61,6 +61,7 @@
             <table class="table table-bordered">
                 <thead>
                     <tr>
+                        <th style="width: 80px;">Image</th>
                         <th>Product</th>
                         <th>Size</th>
                         <th>Quantity</th>
@@ -72,17 +73,54 @@
                     @foreach (var item in Model.Items)
                     {
                         <tr>
-                            <td>@item.Product?.Name</td>
-                            <td>@item.Size</td>
-                            <td>@item.Quantity</td>
+                            <td>
+                                @{
+                                    var coverImage = item.Product?.Images?.FirstOrDefault(i => i.IsCover);
+                                }
+                                @if (coverImage != null)
+                                {
+                                    <img src="@coverImage.ImageUrl" 
+                                         class="img-fluid rounded" 
+                                         style="width: 60px; height: 60px; object-fit: cover;" 
+                                         onerror="this.src='/images/placeholder-dress.jpg'; this.onerror=null;"
+                                         alt="Product Image" />
+                                }
+                                else
+                                {
+                                    <div class="d-flex align-items-center justify-content-center bg-light rounded" 
+                                         style="width: 60px; height: 60px;">
+                                        <i class="fas fa-image text-muted"></i>
+                                    </div>
+                                }
+                            </td>
+                            <td>
+                                <div>
+                                    <strong>@item.Product?.Name</strong>
+                                    @if (!string.IsNullOrEmpty(item.Product?.Description))
+                                    {
+                                        <br />
+                                        <small class="text-muted">@(item.Product.Description.Length > 40 ? item.Product.Description.Substring(0, 40) + "..." : item.Product.Description)</small>
+                                    }
+                                </div>
+                            </td>
+                            <td>
+                                <span class="badge badge-primary" style="font-size: 0.9em;">
+                                    @item.Size
+                                </span>
+                            </td>
+                            <td>
+                                <span class="badge badge-info" style="font-size: 0.9em;">
+                                    @item.Quantity pieces
+                                </span>
+                            </td>
                             <td>$@item.UnitPrice.ToString("F2")</td>
-                            <td>$@item.Price.ToString("F2")</td>
+                            <td><strong>$@item.Price.ToString("F2")</strong></td>
                         </tr>
                     }
                 </tbody>
                 <tfoot>
                     <tr>
-                        <td colspan="4" class="text-right"><strong>Total:</strong></td>
+                        <td colspan="5" class="text-right"><strong>Total:</strong></td>
                         <td><strong>$@Model.TotalAmount.ToString("F2")</strong></td>
                     </tr>
                 </tfoot>


### PR DESCRIPTION
Add product images to Order Details and Admin Products views, and improve size/quantity display in Order Details for better clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd216b9b-61e1-4870-9754-8aa57c87bad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd216b9b-61e1-4870-9754-8aa57c87bad3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>